### PR TITLE
インストール方法の項目を修正

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,7 +9,7 @@ mikutter 0.2.2 以上をインストールしてください。
 
 : $ mkdir -p ~/.mikutter/plugin
 : $ cd ~/.mikutter/plugin
-: $ git clone git://github.com/toshia/mikutter-sub-parts-client.git sub-parts-client
+: $ git clone git://github.com/toshia/mikutter-sub-parts-client.git sub_parts_client
 
 * 使いかた
 起動したら各ツイートの下に「via (Twitterクライアント名)」と表示されます。


### PR DESCRIPTION
プラグインのディレクトリ名とスクリプトのプリフィックスが違っていたので、Miquire::Plugin.eachでスルーされてプラグインが読み込まれなかった