### PR TITLE
deprecatedなやつをどうにかする

### DIFF
--- a/sub_parts_client.rb
+++ b/sub_parts_client.rb
@@ -7,7 +7,7 @@ require 'cairo'
 Plugin.create :sub_parts_client do
   # ツイートが投稿されるのに使われたクライアントアプリケーションの名前をTL上に表示する
   class Gdk::SubPartsClient < Gdk::SubParts
-    regist
+    register
 
     def initialize(*args)
       super
@@ -32,7 +32,7 @@ Plugin.create :sub_parts_client do
 
     private
 
-    def main_message(context = dummy_context)
+    def main_message(context = Cairo::Context.dummy)
       layout = context.create_pango_layout
       layout.font_description = Pango::FontDescription.new(UserConfig[:twitter_tweet_basic_font])
       layout.alignment = Pango::Alignment::RIGHT


### PR DESCRIPTION
言われるままに代替のもので動くことを確認しましたが合っているかはアレです。。

```
warning: /Users/akkie/.rbenv/versions/2.5.1/lib/ruby/2.5.0/rubygems/deprecate.rb:62:in `block (2 levels) in deprecate': NOTE: Gdk::SubPartsClient.regist is deprecated; use register instead. It will be removed on or after 2016-12-01.
```

```
Gdk::SubPartsClient#dummy_context called from /Users/akkie/.mikutter/plugin/sub_parts_client/sub_parts_client.rb:35.
warning: /Users/akkie/.rbenv/versions/2.5.1/lib/ruby/2.5.0/rubygems/deprecate.rb:62:in `block (2 levels) in deprecate': NOTE: Gdk::SubPartsClient#dummy_context is deprecated; use Cairo::Context.dummy instead. It will be removed on or after 2020-06-01.
```